### PR TITLE
ISO8859 encoding support

### DIFF
--- a/BulkSMSGate.php
+++ b/BulkSMSGate.php
@@ -8,6 +8,12 @@ class BulkSMSGate extends CComponent
 {
 
     /**
+     * Classname of encoder class
+     * @var string
+     */
+    public $message_encoder = 'BulkSMSGateUTF16Encoder';
+
+    /**
      * Username, provided by bulksms.com
      * @var string
      */
@@ -31,6 +37,7 @@ class BulkSMSGate extends CComponent
      */
     public $port = 5567;
 
+    private $encoder = null;
 
     public function init()
     {
@@ -47,7 +54,7 @@ class BulkSMSGate extends CComponent
 
         $to = static::prepareTo($to);
 
-        $body = static::unicodeSMS($this->username, $this->password, $message, $to);
+        $body = $this->SMSPostBody($this->username, $this->password, $message, $to);
         $result = static::sendMessage($body, $this->url, $this->port);
 
         Yii::log("Message [$message] sent to [$to] with result: [" . print_r($result, 1) . "]", CLogger::LEVEL_INFO, 'application.external.sms.bulksms');
@@ -131,15 +138,17 @@ class BulkSMSGate extends CComponent
         return $sms_result;
     }
 
-    protected static function unicodeSMS($username, $password, $message, $to)
+    protected function SMSPostBody($username, $password, $message, $to)
     {
-        $postFields = [
-            'username' => $username,
-            'password' => $password,
-            'message' => static::stringToUTF16Hex($message),
-            'msisdn' => $to,
-            'dca' => '16bit'
-        ];
+        if (null === $this->encoder) {
+            $this->encoder = new $this->message_encoder;
+        }
+        $postFields = $this->encoder->SMSPostData(
+            $username,
+            $password,
+            $message,
+            $to
+        );
         return static::makePostBody($postFields);
 
     }
@@ -176,6 +185,24 @@ class BulkSMSGate extends CComponent
     protected static function makeStopDupId()
     {
         return 0;
+    }
+}
+
+interface BulkSMSGateEncoder {
+    public function SMSPostData($username, $password, $message, $to);
+}
+
+
+class BulkSMSGateUTF16Encoder implements BulkSMSGateEncoder {
+    public function SMSPostData($username, $password, $message, $to)
+    {
+        return [
+            'username' => $username,
+            'password' => $password,
+            'message' => static::stringToUTF16Hex($message),
+            'msisdn' => $to,
+            'dca' => '16bit'
+        ];
     }
 
     /**

--- a/BulkSMSGate.php
+++ b/BulkSMSGate.php
@@ -215,3 +215,25 @@ class BulkSMSGateUTF16Encoder implements BulkSMSGateEncoder {
     }
 
 }
+
+class BulkSMSGateISO8859Encoder implements BulkSMSGateEncoder {
+    public function SMSPostData($username, $password, $message, $to)
+    {
+        return [
+            'username' => $username,
+            'password' => $password,
+            'message' => static::stringToISO8859($message),
+            'msisdn' => $to,
+        ];
+    }
+
+    /**
+     * @param $string
+     * @return string
+     */
+    protected static function stringToISO8859($string)
+    {
+        return mb_convert_encoding($string, "ISO-8859-1", "UTF-8");
+    }
+
+}


### PR DESCRIPTION
In cases where full Unicode character sets are not necessary, it can be possible to save credits by using ISO8859-encoded messages instead of UTF-16.

It's implemented by putting message encoding into separate classes to be configured by the user of the component. By default, UTF-16 will still be used, so existing code can remain unchanged no matter what character sets are used in the messages.